### PR TITLE
Add NOP instruction

### DIFF
--- a/cpu1_src/main/cpu.sv
+++ b/cpu1_src/main/cpu.sv
@@ -1,17 +1,20 @@
 module cpu(
     input  logic clk,
     input  logic n_rst,
+    input  logic data,
+    output logic addr,
     output logic led
 );
 
 logic a, next_a;
-
-dff dff(.clk, .n_rst, .in(next_a), .out(a));
-
+dff dff_alu(.clk, .n_rst, .in(next_a), .out(a));
 assign led = a;
 
 always_comb begin
-    next_a = ~a;
+    case(data)
+        1'b0: next_a = a;  // NOP
+        1'b1: next_a = ~a; // NOT
+    endcase
 end
 
 endmodule

--- a/cpu1_src/main/cpu.sv
+++ b/cpu1_src/main/cpu.sv
@@ -10,11 +10,17 @@ logic a, next_a;
 dff dff_alu(.clk, .n_rst, .in(next_a), .out(a));
 assign led = a;
 
+// Program Counter
+logic ip, next_ip;
+dff dff_pc(.clk, .n_rst, .in(next_ip), .out(ip));
+assign addr = ip;
+
 always_comb begin
     case(data)
         1'b0: next_a = a;  // NOP
         1'b1: next_a = ~a; // NOT
     endcase
 end
+assign next_ip = ip + 1'b1;
 
 endmodule

--- a/cpu1_src/main/mother_board.sv
+++ b/cpu1_src/main/mother_board.sv
@@ -1,0 +1,11 @@
+module mother_board(
+    input  clk,
+    input  n_rst,
+    output led
+);
+
+logic addr, data;
+rom rom(.addr, .data);
+cpu cpu(.clk, .n_rst, .data, .addr, .led);
+
+endmodule

--- a/cpu1_src/main/rom.sv
+++ b/cpu1_src/main/rom.sv
@@ -1,0 +1,13 @@
+module rom(
+  input  logic addr,
+  output logic data
+);
+
+always_comb begin
+  case (addr)
+    1'b0: data = 1'b1; // NOT
+    1'b1: data = 1'b0; // NOP
+  endcase
+end
+
+endmodule

--- a/cpu1_src/test/test_cpu.sv
+++ b/cpu1_src/test/test_cpu.sv
@@ -1,17 +1,26 @@
 `timescale 1ns/1ps
 module test_cpu();
 
-    logic clk, n_rst, led;
+    logic clk, n_rst, data, addr, led;
     cpu cpu(.*);
 
     always  #5 clk = ~clk;
     initial clk = 1'b0;
     initial n_rst = 1'b1; // initialize D-flipflop
+    initial data = 1'b0;
 
     initial begin
         #10;
         assign n_rst = 1'b0;
-        // initialize step end
+
+        // Scenario1. NOT
+        #90; assign data = 1'b1;
+
+        // Scenario1. NOP
+        #100; assign data = 1'b0; // always 0
+        #100; assign data = 1'b1;
+        #90; assign data = 1'b0;  // always 1
+
         #2000;
         $finish();
     end

--- a/cpu1_src/test/test_mother_board.sv
+++ b/cpu1_src/test/test_mother_board.sv
@@ -1,0 +1,18 @@
+`timescale 1ns/1ps
+module test_mother_board();
+
+    logic clk, n_rst, led;
+    mother_board mother_board(.*);
+
+    always  #5 clk = ~clk;
+    initial clk = 1'b0;
+    initial n_rst = 1'b1; // initialize D-flipflop
+
+    initial begin
+        #10;
+        assign n_rst = 1'b0;
+
+        #2000;
+        $finish();
+    end
+endmodule


### PR DESCRIPTION
This PR adds NOP instruction to `cpu` module.

|  data  | instruction |
| :----: | :----: |
|  0 |  NOP | 
|  1  |  NOT |

This PR also adds a temporary PC and ROM module in order to check the behavior of multiple instructions.

Simulation results: 
![image](https://user-images.githubusercontent.com/20817743/94145396-755c4500-fead-11ea-8c95-b0e7e7bff5ee.png)
