### PR TITLE
Use 4-bit wire for input switch and output LED

### DIFF
--- a/cpu1_src/board/xilinx-arty-s7/constraint.xdc
+++ b/cpu1_src/board/xilinx-arty-s7/constraint.xdc
@@ -2,8 +2,17 @@
 set_property -dict {PACKAGE_PIN R2  IOSTANDARD LVCMOS33} [get_ports {pin_clock}];
 create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports {pin_clock}];
 
+# SWITCH
+set_property -dict {PACKAGE_PIN H14 IOSTANDARD LVCMOS33} [get_ports {pin_switch[0]}];
+set_property -dict {PACKAGE_PIN H18 IOSTANDARD LVCMOS33} [get_ports {pin_switch[1]}];
+set_property -dict {PACKAGE_PIN G18 IOSTANDARD LVCMOS33} [get_ports {pin_switch[2]}];
+set_property -dict {PACKAGE_PIN M5  IOSTANDARD LVCMOS33} [get_ports {pin_switch[3]}];
+
 # LED
-set_property -dict {PACKAGE_PIN E18 IOSTANDARD LVCMOS33} [get_ports {pin_led}];
+set_property -dict {PACKAGE_PIN E18 IOSTANDARD LVCMOS33} [get_ports {pin_led[0]}];
+set_property -dict {PACKAGE_PIN F13 IOSTANDARD LVCMOS33} [get_ports {pin_led[1]}];
+set_property -dict {PACKAGE_PIN E13 IOSTANDARD LVCMOS33} [get_ports {pin_led[2]}];
+set_property -dict {PACKAGE_PIN H15 IOSTANDARD LVCMOS33} [get_ports {pin_led[3]}];
 
 # RESET
 set_property -dict {PACKAGE_PIN C18 IOSTANDARD LVCMOS33} [get_ports {pin_n_reset}];

--- a/cpu1_src/main/cpu.sv
+++ b/cpu1_src/main/cpu.sv
@@ -1,9 +1,9 @@
 module cpu(
-    input  logic clk,
-    input  logic n_rst,
-    input  logic data,
-    output logic addr,
-    output logic led
+    input  logic       clk,
+    input  logic       n_rst,
+    input  logic       data,
+    output logic       addr,
+    output logic [3:0] led
 );
 
 logic a, next_a;

--- a/cpu1_src/main/mother_board.sv
+++ b/cpu1_src/main/mother_board.sv
@@ -1,7 +1,8 @@
 module mother_board(
-    input  clk,
-    input  n_rst,
-    output led
+    input  logic       clk,
+    input  logic       n_rst,
+    input  logic [3:0] switch,
+    output logic [3:0] led
 );
 
 logic addr, data;

--- a/cpu1_src/main/top.sv
+++ b/cpu1_src/main/top.sv
@@ -1,7 +1,8 @@
 module top(
-  input  logic pin_clock,
-  input  logic pin_n_reset,
-  output logic pin_led
+  input  logic       pin_clock,
+  input  logic       pin_n_reset,
+  input  logic [3:0] pin_switch,
+  output logic [3:0] pin_led
 );
   logic clk;
   prescaler #(.RATIO(100_000_000)) prescaler(
@@ -9,5 +10,5 @@ module top(
     .slow_clock(clk)
   );
 
-  mother_board mother_board(.clk, .n_rst(pin_n_reset), .led(pin_led));
+  mother_board mother_board(.clk, .n_rst(pin_n_reset), .switch(pin_switch), .led(pin_led));
 endmodule

--- a/cpu1_src/test/test_cpu.sv
+++ b/cpu1_src/test/test_cpu.sv
@@ -1,7 +1,8 @@
 `timescale 1ns/1ps
 module test_cpu();
 
-    logic clk, n_rst, data, addr, led;
+    logic clk, n_rst, data, addr;
+    logic [3:0] led;
     cpu cpu(.*);
 
     always  #5 clk = ~clk;

--- a/cpu1_src/test/test_mother_board.sv
+++ b/cpu1_src/test/test_mother_board.sv
@@ -1,7 +1,8 @@
 `timescale 1ns/1ps
 module test_mother_board();
 
-    logic clk, n_rst, led;
+    logic clk, n_rst;
+    logic [3:0] switch, led;
     mother_board mother_board(.*);
 
     always  #5 clk = ~clk;


### PR DESCRIPTION
This PR
* changed the output LED to 4 bits
* added a 4-bit switch as an input for cpu
* added constraints for them
  * The target hardware for this repository is the Arty S7-50 board
