### PR TITLE
Add TD4 architecture instructions

### DIFF
--- a/cpu1_src/main/cpu.sv
+++ b/cpu1_src/main/cpu.sv
@@ -8,7 +8,10 @@ module cpu(
 );
 
 logic [3:0] a, next_a;
-dff4 dff_alu(.clk, .n_rst, .in(next_a), .out(a));
+dff4 dff_a(.clk, .n_rst, .in(next_a), .out(a));
+
+logic [3:0] b, next_b;
+dff4 dff_b(.clk, .n_rst, .in(next_b), .out(b));
 
 // Output Register
 logic [3:0] out, next_out;

--- a/cpu1_src/main/cpu.sv
+++ b/cpu1_src/main/cpu.sv
@@ -9,7 +9,11 @@ module cpu(
 
 logic [3:0] a, next_a;
 dff4 dff_alu(.clk, .n_rst, .in(next_a), .out(a));
-assign led = a;
+
+// Output Register
+logic [3:0] out, next_out;
+dff4 dff_output(.clk, .n_rst, .in(next_out), .out(out));
+assign led = out;
 
 // Program Counter
 logic ip, next_ip;
@@ -18,8 +22,8 @@ assign addr = ip;
 
 always_comb begin
     unique case(data)
-        0: next_a = 0;       // LED OFF
-        1: next_a = switch;  // LED ON
+        0: next_out = 0;       // LED OFF
+        1: next_out = switch;  // LED ON
         default: ;
     endcase
 end

--- a/cpu1_src/main/cpu.sv
+++ b/cpu1_src/main/cpu.sv
@@ -26,12 +26,16 @@ assign addr = ip;
 
 always_comb begin
     unique case(opecode)
-        0: next_out = 0;       // LED OFF
-        1: next_b = a;         // MOV A, B
-        4: next_a = b;         // MOV B, A
-        2: next_a = switch;    // IN A
-        6: next_b = switch;    // IN B
-        9: next_out = b;       // OUT B
+        1:  next_b = a;         // MOV A, B
+        4:  next_a = b;         // MOV B, A
+        3:  next_a = imm;       // MOV A, IMM
+        7:  next_b = imm;       // MOV B, IMM
+        2:  next_a = switch;    // IN A
+        6:  next_b = switch;    // IN B
+        9:  next_out = b;       // OUT B
+        11: next_out = imm;     // OUT IMM
+        0:  next_a = a + imm;   // ADD A, IMM
+        5:  next_b = b + imm;   // ADD B, IMM
         default: ;
     endcase
 end

--- a/cpu1_src/main/cpu.sv
+++ b/cpu1_src/main/cpu.sv
@@ -1,7 +1,7 @@
 module cpu(
     input  logic       clk,
     input  logic       n_rst,
-    input  logic       data,
+    input  logic [3:0] data,
     input  logic [3:0] switch,
     output logic       addr,
     output logic [3:0] led
@@ -17,9 +17,10 @@ dff dff_pc(.clk, .n_rst, .in(next_ip), .out(ip));
 assign addr = ip;
 
 always_comb begin
-    case(data)
-        1'b0: next_a = 0;       // LED OFF
-        1'b1: next_a = switch;  // LED ON
+    unique case(data)
+        0: next_a = 0;       // LED OFF
+        1: next_a = switch;  // LED ON
+        default: ;
     endcase
 end
 assign next_ip = ip + 1'b1;

--- a/cpu1_src/main/cpu.sv
+++ b/cpu1_src/main/cpu.sv
@@ -29,9 +29,14 @@ dff4 dff_ip(.clk, .n_rst, .in(next_ip), .out(ip));
 
 always_comb begin
     led = out;
-    next_cf = 1'b0;
     addr = ip;
-    next_ip = ip + 1'b1;
+
+    next_cf = 1'b0;
+    next_ip = ip + 1;
+    next_a = a;
+    next_b = b;
+    next_out = out;
+
     unique case(opecode)
         1:  next_b = a;                    // MOV A, B
         4:  next_a = b;                    // MOV B, A

--- a/cpu1_src/main/cpu.sv
+++ b/cpu1_src/main/cpu.sv
@@ -43,6 +43,8 @@ always_comb begin
         11: next_out = imm;                // OUT IMM
         0:  {next_cf, next_a} = a + imm;   // ADD A, IMM
         5:  {next_cf, next_b} = b + imm;   // ADD B, IMM
+        15: next_ip = imm;                 // JMP IMM
+        14: next_ip = cf ? ip + 1 : imm;   // JNC IMM
         default: ;
     endcase
 end

--- a/cpu1_src/main/cpu.sv
+++ b/cpu1_src/main/cpu.sv
@@ -26,7 +26,11 @@ assign addr = ip;
 always_comb begin
     unique case(data)
         0: next_out = 0;       // LED OFF
-        1: next_out = switch;  // LED ON
+        1: next_b = a;         // MOV A, B
+        4: next_a = b;         // MOV B, A
+        2: next_a = switch;    // IN A
+        6: next_b = switch;    // IN B
+        9: next_out = b;       // OUT B
         default: ;
     endcase
 end

--- a/cpu1_src/main/cpu.sv
+++ b/cpu1_src/main/cpu.sv
@@ -4,7 +4,7 @@ module cpu(
     input  logic [3:0] opecode,
     input  logic [3:0] imm,
     input  logic [3:0] switch,
-    output logic       addr,
+    output logic [3:0] addr,
     output logic [3:0] led
 );
 
@@ -18,19 +18,20 @@ dff4 dff_b(.clk, .n_rst, .in(next_b), .out(b));
 // Output register
 logic [3:0] out, next_out;
 dff4 dff_output(.clk, .n_rst, .in(next_out), .out(out));
-assign led = out;
 
 // Flag register
 logic cf, next_cf;
 dff dff_flag(.clk, .n_rst, .in(next_cf), .out(cf));
-assign next_cf = cf;
 
-// Program Counter
-logic ip, next_ip;
-dff dff_pc(.clk, .n_rst, .in(next_ip), .out(ip));
-assign addr = ip;
+// Instruction register
+logic [3:0] ip, next_ip;
+dff4 dff_ip(.clk, .n_rst, .in(next_ip), .out(ip));
 
 always_comb begin
+    led = out;
+    next_cf = 1'b0;
+    addr = ip;
+    next_ip = ip + 1'b1;
     unique case(opecode)
         1:  next_b = a;                    // MOV A, B
         4:  next_a = b;                    // MOV B, A
@@ -45,6 +46,5 @@ always_comb begin
         default: ;
     endcase
 end
-assign next_ip = ip + 1'b1;
 
 endmodule

--- a/cpu1_src/main/cpu.sv
+++ b/cpu1_src/main/cpu.sv
@@ -1,7 +1,8 @@
 module cpu(
     input  logic       clk,
     input  logic       n_rst,
-    input  logic [3:0] data,
+    input  logic [3:0] opecode,
+    input  logic [3:0] imm,
     input  logic [3:0] switch,
     output logic       addr,
     output logic [3:0] led
@@ -24,7 +25,7 @@ dff dff_pc(.clk, .n_rst, .in(next_ip), .out(ip));
 assign addr = ip;
 
 always_comb begin
-    unique case(data)
+    unique case(opecode)
         0: next_out = 0;       // LED OFF
         1: next_b = a;         // MOV A, B
         4: next_a = b;         // MOV B, A

--- a/cpu1_src/main/cpu.sv
+++ b/cpu1_src/main/cpu.sv
@@ -8,16 +8,22 @@ module cpu(
     output logic [3:0] led
 );
 
+// General-purpose register
 logic [3:0] a, next_a;
 dff4 dff_a(.clk, .n_rst, .in(next_a), .out(a));
 
 logic [3:0] b, next_b;
 dff4 dff_b(.clk, .n_rst, .in(next_b), .out(b));
 
-// Output Register
+// Output register
 logic [3:0] out, next_out;
 dff4 dff_output(.clk, .n_rst, .in(next_out), .out(out));
 assign led = out;
+
+// Flag register
+logic cf, next_cf;
+dff dff_flag(.clk, .n_rst, .in(next_cf), .out(cf));
+assign next_cf = cf;
 
 // Program Counter
 logic ip, next_ip;
@@ -26,16 +32,16 @@ assign addr = ip;
 
 always_comb begin
     unique case(opecode)
-        1:  next_b = a;         // MOV A, B
-        4:  next_a = b;         // MOV B, A
-        3:  next_a = imm;       // MOV A, IMM
-        7:  next_b = imm;       // MOV B, IMM
-        2:  next_a = switch;    // IN A
-        6:  next_b = switch;    // IN B
-        9:  next_out = b;       // OUT B
-        11: next_out = imm;     // OUT IMM
-        0:  next_a = a + imm;   // ADD A, IMM
-        5:  next_b = b + imm;   // ADD B, IMM
+        1:  next_b = a;                    // MOV A, B
+        4:  next_a = b;                    // MOV B, A
+        3:  next_a = imm;                  // MOV A, IMM
+        7:  next_b = imm;                  // MOV B, IMM
+        2:  next_a = switch;               // IN A
+        6:  next_b = switch;               // IN B
+        9:  next_out = b;                  // OUT B
+        11: next_out = imm;                // OUT IMM
+        0:  {next_cf, next_a} = a + imm;   // ADD A, IMM
+        5:  {next_cf, next_b} = b + imm;   // ADD B, IMM
         default: ;
     endcase
 end

--- a/cpu1_src/main/dff.sv
+++ b/cpu1_src/main/dff.sv
@@ -7,7 +7,7 @@ module dff(
 
 logic a;
 always_ff @(posedge clk) begin
-    if (-n_rst) a <= 1'b0;
+    if (~n_rst) a <= 1'b0;
     else        a <= in;
 end
 assign out = a;

--- a/cpu1_src/main/dff4.sv
+++ b/cpu1_src/main/dff4.sv
@@ -8,7 +8,7 @@ module dff4(
 
 logic [3:0] a;
 always_ff @(posedge clk) begin
-    if (-n_rst) a <= 'b0;
+    if (~n_rst) a <= 'b0;
     else        a <= in;
 end
 assign out = a;

--- a/cpu1_src/main/mother_board.sv
+++ b/cpu1_src/main/mother_board.sv
@@ -5,8 +5,8 @@ module mother_board(
     output logic [3:0] led
 );
 
-logic addr, data;
-rom rom(.addr, .data);
-cpu cpu(.clk, .n_rst, .data, .switch, .addr, .led);
+logic [3:0] addr, opecode, imm;
+rom rom(.addr, .opecode, .imm);
+cpu cpu(.clk, .n_rst, .opecode, .imm, .switch, .addr, .led);
 
 endmodule

--- a/cpu1_src/main/rom.sv
+++ b/cpu1_src/main/rom.sv
@@ -3,14 +3,32 @@ module rom(
   output logic [3:0] opecode,
   output logic [3:0] imm
 );
-
 always_comb begin
-  imm = 0;
-  opecode = 0;
-  case (addr)
-    8'b0: opecode = 1; // NOT
-    8'b1: opecode = 0; // NOP
-    default: ;
+  case (addr)                     // addr  assembler
+    4'b0000: opecode = 4'b0110;   // 0     IN  B
+    4'b0001: opecode = 4'b1001;   // 1     OUT B
+    4'b0010: opecode = 4'b0011;   // 2     MOV A, 15
+    4'b0011: opecode = 4'b0000;   // 3     ADD A, 1
+    4'b0100: opecode = 4'b1110;   // 4     JNC    3
+    4'b0101: opecode = 4'b0101;   // 5     ADD B, 1
+    4'b0110: opecode = 4'b1110;   // 6     JNC    1
+    4'b0111: opecode = 4'b1011;   // 7     OUT    0
+    4'b1000: opecode = 4'b1011;   // 8     OUT    15
+    4'b1001: opecode = 4'b1111;   // 9     JMP    7
+    default: opecode = 4'b0000;
+  endcase
+  case (addr)                     // addr  assembler
+    4'b0000: imm = 4'b0000;       // 0     IN  B
+    4'b0001: imm = 4'b0000;       // 1     OUT B
+    4'b0010: imm = 4'b1111;       // 2     MOV A, 15
+    4'b0011: imm = 4'b0001;       // 3     ADD A, 1
+    4'b0100: imm = 4'b0011;       // 4     JNC    3
+    4'b0101: imm = 4'b0001;       // 5     ADD B, 1
+    4'b0110: imm = 4'b0001;       // 6     JNC    1
+    4'b0111: imm = 4'b0000;       // 7     OUT    0
+    4'b1000: imm = 4'b1111;       // 8     OUT    15
+    4'b1001: imm = 4'b0111;       // 9     JMP    7
+    default: imm = 4'b0000;
   endcase
 end
 

--- a/cpu1_src/main/rom.sv
+++ b/cpu1_src/main/rom.sv
@@ -1,12 +1,12 @@
 module rom(
-  input  logic addr,
-  output logic data
+  input  logic       addr,
+  output logic [3:0] data
 );
 
 always_comb begin
   case (addr)
-    1'b0: data = 1'b1; // NOT
-    1'b1: data = 1'b0; // NOP
+    1'b0: data = 1; // NOT
+    1'b1: data = 0; // NOP
   endcase
 end
 

--- a/cpu1_src/main/rom.sv
+++ b/cpu1_src/main/rom.sv
@@ -1,12 +1,14 @@
 module rom(
   input  logic       addr,
-  output logic [3:0] data
+  output logic [3:0] opecode,
+  output logic [3:0] imm
 );
 
 always_comb begin
+  imm = 0;
   case (addr)
-    1'b0: data = 1; // NOT
-    1'b1: data = 0; // NOP
+    8'b0: opecode = 1; // NOT
+    8'b1: opecode = 0; // NOP
   endcase
 end
 

--- a/cpu1_src/main/rom.sv
+++ b/cpu1_src/main/rom.sv
@@ -1,14 +1,16 @@
 module rom(
-  input  logic       addr,
+  input  logic [3:0] addr,
   output logic [3:0] opecode,
   output logic [3:0] imm
 );
 
 always_comb begin
   imm = 0;
+  opecode = 0;
   case (addr)
     8'b0: opecode = 1; // NOT
     8'b1: opecode = 0; // NOP
+    default: ;
   endcase
 end
 

--- a/cpu1_src/test/test_cpu.sv
+++ b/cpu1_src/test/test_cpu.sv
@@ -20,13 +20,19 @@ module test_cpu();
         #90; assign opecode = 1; assign switch = 5;
 
         // Scenario1. LED OFF
-        #100; assign opecode = 0; // always 0
+        #50; assign opecode = 0; // always 0
 
-        #100; assign switch = 3; assign opecode = 2; // IN A
-        #100; assign opecode = 1; // MOV A, B
-        #100; assign switch = 6; assign opecode = 6; // IN B
-        #100; assign opecode = 4; // MOV B, A
-        #100; assign opecode = 9; // OUT B
+        #50; assign switch = 3; assign opecode = 2; // IN A
+        #50; assign opecode = 1; // MOV A, B
+        #50; assign switch = 6; assign opecode = 6; // IN B
+        #50; assign opecode = 4; // MOV B, A
+        #50; assign opecode = 9; // OUT B
+
+        #50; assign opecode = 3; assign imm = 0; // MOV A, IMM
+        #50; assign opecode = 7; assign imm = 1; // MOV A, IMM
+
+        #50; assign opecode = 0; assign imm = 1; // ADD A, IMM
+        #50; assign opecode = 5; assign imm = 1; // ADD A, IMM
 
         #2000;
         $finish();

--- a/cpu1_src/test/test_cpu.sv
+++ b/cpu1_src/test/test_cpu.sv
@@ -1,8 +1,8 @@
 `timescale 1ns/1ps
 module test_cpu();
 
-    logic clk, n_rst, addr;
-    logic [3:0] opecode, imm, led, switch;
+    logic clk, n_rst;
+    logic [3:0] addr, opecode, imm, led, switch;
     cpu cpu(.*);
 
     always  #5 clk = ~clk;

--- a/cpu1_src/test/test_cpu.sv
+++ b/cpu1_src/test/test_cpu.sv
@@ -7,14 +7,14 @@ module test_cpu();
 
     always  #5 clk = ~clk;
     initial clk = 1'b0;
-    initial n_rst = 1'b1; // initialize D-flipflop
+    initial n_rst = 1'b0; // initialize D-flipflop
     initial opecode = 0;
     initial imm = 0;
     initial switch = 'b1;
 
     initial begin
         #10;
-        assign n_rst = 1'b0;
+        assign n_rst = 1'b1;
 
         // Scenario1. LED ON
         #90; assign opecode = 1; assign switch = 5;

--- a/cpu1_src/test/test_cpu.sv
+++ b/cpu1_src/test/test_cpu.sv
@@ -2,13 +2,14 @@
 module test_cpu();
 
     logic clk, n_rst, addr;
-    logic [3:0] data, led, switch;
+    logic [3:0] opecode, imm, led, switch;
     cpu cpu(.*);
 
     always  #5 clk = ~clk;
     initial clk = 1'b0;
     initial n_rst = 1'b1; // initialize D-flipflop
-    initial data = 0;
+    initial opecode = 0;
+    initial imm = 0;
     initial switch = 'b1;
 
     initial begin
@@ -16,16 +17,16 @@ module test_cpu();
         assign n_rst = 1'b0;
 
         // Scenario1. LED ON
-        #90; assign data = 1; assign switch = 5;
+        #90; assign opecode = 1; assign switch = 5;
 
         // Scenario1. LED OFF
-        #100; assign data = 0; // always 0
+        #100; assign opecode = 0; // always 0
 
-        #100; assign switch = 3; assign data = 2; // IN A
-        #100; assign data = 1; // MOV A, B
-        #100; assign switch = 6; assign data = 6; // IN B
-        #100; assign data = 4; // MOV B, A
-        #100; assign data = 9; // OUT B
+        #100; assign switch = 3; assign opecode = 2; // IN A
+        #100; assign opecode = 1; // MOV A, B
+        #100; assign switch = 6; assign opecode = 6; // IN B
+        #100; assign opecode = 4; // MOV B, A
+        #100; assign opecode = 9; // OUT B
 
         #2000;
         $finish();

--- a/cpu1_src/test/test_cpu.sv
+++ b/cpu1_src/test/test_cpu.sv
@@ -34,6 +34,11 @@ module test_cpu();
         #50; assign opecode = 0; assign imm = 1; // ADD A, IMM
         #50; assign opecode = 5; assign imm = 1; // ADD A, IMM
 
+        #50; assign opecode = 15; assign imm = 3; // JMP IMM (false)
+        #50; assign opecode = 3; assign imm = 10; // MOV A, IMM
+        #10; assign opecode = 0; assign imm = 10; // ADD A, IMM
+        #30; assign opecode = 14; assign imm = 7; // JNC IMM (true)
+
         #2000;
         $finish();
     end

--- a/cpu1_src/test/test_cpu.sv
+++ b/cpu1_src/test/test_cpu.sv
@@ -1,14 +1,14 @@
 `timescale 1ns/1ps
 module test_cpu();
 
-    logic clk, n_rst, data, addr;
-    logic [3:0] led, switch;
+    logic clk, n_rst, addr;
+    logic [3:0] data, led, switch;
     cpu cpu(.*);
 
     always  #5 clk = ~clk;
     initial clk = 1'b0;
     initial n_rst = 1'b1; // initialize D-flipflop
-    initial data = 1'b0;
+    initial data = 0;
     initial switch = 'b1;
 
     initial begin
@@ -16,10 +16,10 @@ module test_cpu();
         assign n_rst = 1'b0;
 
         // Scenario1. LED ON
-        #90; assign data = 1'b1; assign switch = 5;
+        #90; assign data = 1; assign switch = 5;
 
         // Scenario1. LED OFF
-        #100; assign data = 1'b0; // always 0
+        #100; assign data = 0; // always 0
 
         #2000;
         $finish();

--- a/cpu1_src/test/test_cpu.sv
+++ b/cpu1_src/test/test_cpu.sv
@@ -21,6 +21,12 @@ module test_cpu();
         // Scenario1. LED OFF
         #100; assign data = 0; // always 0
 
+        #100; assign switch = 3; assign data = 2; // IN A
+        #100; assign data = 1; // MOV A, B
+        #100; assign switch = 6; assign data = 6; // IN B
+        #100; assign data = 4; // MOV B, A
+        #100; assign data = 9; // OUT B
+
         #2000;
         $finish();
     end

--- a/cpu1_src/test/test_mother_board.sv
+++ b/cpu1_src/test/test_mother_board.sv
@@ -7,12 +7,12 @@ module test_mother_board();
 
     always  #5 clk = ~clk;
     initial clk = 1'b0;
-    initial n_rst = 1'b1; // initialize D-flipflop
-    initial switch = 'b1;
+    initial n_rst = 1'b0; // initialize D-flipflop
+    initial switch = 10;
 
     initial begin
         #10;
-        assign n_rst = 1'b0;
+        assign n_rst = 1'b1;
 
         #2000;
         $finish();


### PR DESCRIPTION
This PR implements the instructions of TD4 architecture. 

Sample timer program:
![image](https://user-images.githubusercontent.com/20817743/94256200-61bfe580-ff64-11ea-95ac-2941382c9f9d.png)

Instructions: 
| opecode | description |
| --------- | ------------- |
|  `0000` |  `ADD A IMM` |
|  `0001` |  `MOV A B` |
|  `0010` |  `IN A` |
|  `0011` |  `MOV A IMM` |
|  `0100` |  `MOV B A` |
|  `0101` |  `ADD B IMM` |
|  `0110` |  `IN B` |
|  `0111` |  `MOV B IMM` |
|  `1000` |  `NOP` |
|  `1001` |  `OUT B` |
|  `1010` |  `NOP` |
|  `1011` |  `OUT IMM` |
|  `1100` |  `NOP` |
|  `1101` |  `NOP` |
|  `1110` |  `IN B` |
|  `1111` |  `JMP IMM` |